### PR TITLE
feat(#3541756): set default CORS allowedHeaders.

### DIFF
--- a/src/DruxtServiceProvider.php
+++ b/src/DruxtServiceProvider.php
@@ -16,7 +16,14 @@ class DruxtServiceProvider implements ServiceModifierInterface {
   public function alter(ContainerBuilder $container) {
     $cors_config = $container->getParameter('cors.config');
     if (!$cors_config['enabled']) {
+      // Enable CORS by default.
       $cors_config['enabled'] = TRUE;
+
+      // Set allowed headers to '*' by default.
+      if (count($cors_config['allowedHeaders']) === 0) {
+        $cors_config['allowedHeaders'][] = '*';
+      }
+
       $container->setParameter('cors.config', $cors_config);
     }
   }

--- a/src/DruxtServiceProvider.php
+++ b/src/DruxtServiceProvider.php
@@ -19,9 +19,9 @@ class DruxtServiceProvider implements ServiceModifierInterface {
       // Enable CORS by default.
       $cors_config['enabled'] = TRUE;
 
-      // Set allowed headers to '*' by default.
-      if (count($cors_config['allowedHeaders']) === 0) {
-        $cors_config['allowedHeaders'][] = '*';
+      // Set allowed headers to '*' by default when empty/undefined.
+      if (empty($cors_config['allowedHeaders'])) {
+        $cors_config['allowedHeaders'] = ['*'];
       }
 
       $container->setParameter('cors.config', $cors_config);

--- a/tests/src/Functional/CorsIntegrationTest.php
+++ b/tests/src/Functional/CorsIntegrationTest.php
@@ -27,7 +27,7 @@ class CorsIntegrationTest extends BrowserTestBase {
   public function testCrossSiteRequestEnabled() {
     $cors_config = $this->container->getParameter('cors.config');
     $this->assertTrue($cors_config['enabled']);
-    $this->assertEquals($cors_config['allowedHeaders'][0], '*');
+    $this->assertContains('*', $cors_config['allowedHeaders']);
   }
 
 }

--- a/tests/src/Functional/CorsIntegrationTest.php
+++ b/tests/src/Functional/CorsIntegrationTest.php
@@ -27,6 +27,7 @@ class CorsIntegrationTest extends BrowserTestBase {
   public function testCrossSiteRequestEnabled() {
     $cors_config = $this->container->getParameter('cors.config');
     $this->assertTrue($cors_config['enabled']);
+    $this->assertEquals($cors_config['allowedHeaders'][0], '*');
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - CORS is now enabled by default with a wildcard allowed-headers setting when none is specified, improving cross-site request compatibility out of the box.
- Tests
  - Expanded integration tests to verify the default wildcard allowed-headers behavior for CORS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->